### PR TITLE
ci: build and push docker images

### DIFF
--- a/.github/workflows/build_docker_production.yml
+++ b/.github/workflows/build_docker_production.yml
@@ -7,7 +7,6 @@ concurrency:
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/build_docker_production.yml
+++ b/.github/workflows/build_docker_production.yml
@@ -1,0 +1,70 @@
+name: Build & Publish the container image - production
+
+concurrency:
+  group: build_docker_production
+  cancel-in-progress: true
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-deploy:
+    name: Build and Publish (on production)
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Log into Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_LOGIN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up QEMU for ARM build
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: "./Dockerfile"
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DEV_CONTAINER_REGISTRY_URL }}/exordelabs/exorde-client:${{ github.event.release.tag_name }}
+            ${{ secrets.DEV_CONTAINER_REGISTRY_URL }}/exordelabs/exorde-client:latest
+
+      - name: Send a message to slack if CI has succeeded
+        if: ${{ success() }}
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "✓ The CI _'${{ github.workflow }}'_ of repository _${{ github.repository }}_ has been successfully deployed. Link to release: ${{ github.event.release.html_url }}."
+            }
+
+      - name: Send a message to slack if CI has failed
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": ":x: The CI _'${{ github.workflow }}'_ of repository _${{ github.repository }}_ has failed. Link to release: ${{ github.event.release.html_url }}."
+            }

--- a/.github/workflows/build_docker_production.yml
+++ b/.github/workflows/build_docker_production.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 permissions:
   contents: read

--- a/.github/workflows/build_docker_staging.yml
+++ b/.github/workflows/build_docker_staging.yml
@@ -1,0 +1,69 @@
+name: Build & Publish the container image - staging
+
+concurrency:
+  group: build_docker_staging
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-deploy:
+    name: Build and Publish (on staging)
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set commit sha short
+        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
+      - name: Log into registry ${{ secrets.DEV_CONTAINER_REGISTRY_URL }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.DEV_CONTAINER_REGISTRY_URL }}
+          username: ${{ secrets.DEV_CONTAINER_REGISTRY_LOGIN }}
+          password: ${{ secrets.DEV_CONTAINER_REGISTRY_SECRET_KEY }}
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: "./Dockerfile"
+          push: true
+          tags: |
+            ${{ secrets.DEV_CONTAINER_REGISTRY_URL }}/exorde/exorde:${{ env.SHORT_SHA }}
+            ${{ secrets.DEV_CONTAINER_REGISTRY_URL }}/exorde/exorde:latest
+
+      - name: Send a message to slack if CI has succeeded
+        if: ${{ success() }}
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "✓ The CI _'${{ github.workflow }}'_ of repository _${{ github.repository }}_ has been successfully deployed. Link to PR/commit: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}."
+            }
+
+      - name: Send a message to slack if CI has failed
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": ":x: The CI _'${{ github.workflow }}'_ of repository _${{ github.repository }}_ has failed. Link to PR/commit: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}."
+            }


### PR DESCRIPTION
Cette CI effectue le build de l'image Docker et la publie : 
- sur le dépot privé d'images de développement d'Exorde Labs à chaque PR/push sur main
- sur docker hub à chaque publication de release

Les builds de dev n'utilisent pas semver pour les tags, mais uniquement l'id du commit pour lier le build au commit associé.

Les builds de prod utilisent le tag de la release.